### PR TITLE
Allow script in javadoc comments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,12 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
+						<configuration>
+							<additionalJOptions>
+								<additionalJOption>-Xdoclint:none</additionalJOption>
+								<additionalJOption>--allow-script-in-comments</additionalJOption>
+							</additionalJOptions>
+						</configuration>
 						<executions>
 							<execution>
 							<id>attach-javadocs</id>


### PR DESCRIPTION
@rotty3000 Sorry, I missed to add this in the last PR. I saw the build failed on Jenkins.