### PR TITLE
cleaner fix to initialize the servlet context for OWB

### DIFF
--- a/cdi-owb/pom.xml
+++ b/cdi-owb/pom.xml
@@ -60,6 +60,12 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>biz.aQute.bnd</groupId>
+			<artifactId>biz.aQute.bnd.annotation</artifactId>
+			<version>${bnd.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.aries.cdi</groupId>
 			<artifactId>org.apache.aries.cdi.extra</artifactId>
 			<version>${project.version}</version>

--- a/cdi-owb/src/main/java/org/apache/aries/cdi/owb/core/OWBCDIContainerInitializer.java
+++ b/cdi-owb/src/main/java/org/apache/aries/cdi/owb/core/OWBCDIContainerInitializer.java
@@ -162,7 +162,9 @@ public class OWBCDIContainerInitializer extends CDIContainerInitializer {
 						properties.putAll(entry.getValue());
 
 						// Extract the start instance to ensure it works with the configured services (properties)
-						startObject = StartObjectSupplier.class.cast(entry.getKey()).getStartObject();
+						final StartObjectSupplier<?> objectSupplier = StartObjectSupplier.class.cast(entry.getKey());
+						properties.putAll(objectSupplier.properties());
+						startObject = objectSupplier.getStartObject();
 					});
 
 			bootstrap = new WebBeansContext(services, properties) {

--- a/cdi-owb/src/main/java/org/apache/aries/cdi/owb/spi/StartObjectSupplier.java
+++ b/cdi-owb/src/main/java/org/apache/aries/cdi/owb/spi/StartObjectSupplier.java
@@ -13,10 +13,35 @@
  */
 package org.apache.aries.cdi.owb.spi;
 
+import static java.util.Collections.emptyMap;
+
+import java.util.Map;
+import aQute.bnd.annotation.baseline.BaselineIgnore;
+
+/**
+ * Enables to customize the OWB context creation.
+ * @param <T> the type of start object provided.
+ */
 public interface StartObjectSupplier<T> {
+	/**
+	 * @return cdi start instance (instance which can be observed when appscope is initialized).
+	 */
 	T getStartObject();
 
+	/**
+	 * @return enable to select the supplier to use when ambiguous (like ranking a bit), higher is selected.
+	 */
 	default int ordinal() {
 		return 0;
+	}
+
+	/**
+	 * TIP: this enables to customize the context from a bundle extension and not a service.
+	 *
+	 * @return a set of OWB properties.
+	 */
+	@BaselineIgnore("1.1.1") // does not break backward compat but baseline does not see "default"
+	default Map<String, String> properties() {
+		return emptyMap();
 	}
 }


### PR DESCRIPTION
The enhancements are:

1. enhance owb spi to enable to customize OWB properties from an extension in the bundle
2. initialize the servlet context way sooner (beginning of cdi lifecycle) instead of the end