### PR TITLE
ARIES-1982 Aries CDI doesn't run on upcoming version of OSGi framework

### DIFF
--- a/cdi-spi/pom.xml
+++ b/cdi-spi/pom.xml
@@ -51,6 +51,7 @@
 				<artifactId>bnd-maven-plugin</artifactId>
 				<configuration>
 					<bnd><![CDATA[
+                        Import-Package: org.osgi.framework;version='[1.9,2)', *
 						-cdiannotations:
 					]]></bnd>
 				</configuration>


### PR DESCRIPTION
Signed-off-by: Raymond Augé <rotty3000@apache.org>