### PR TITLE
switch dependencies to published version

### DIFF
--- a/cdi-itests/owb-itest.bndrun
+++ b/cdi-itests/owb-itest.bndrun
@@ -19,6 +19,7 @@
 -runblacklist: \
 	osgi.identity;filter:='(osgi.identity=*weld*)'
 -runbundles: \
+	assertj-core;version='[3.16.1,3.16.2)',\
 	biz.aQute.junit;version='[5.1.0,5.1.1)',\
 	javax.servlet.jsp-api;version='[2.3.3,2.3.4)',\
 	openwebbeans-impl;version='[2.0.13,2.0.14)',\

--- a/cdi-itests/pom.xml
+++ b/cdi-itests/pom.xml
@@ -147,7 +147,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.osgi</groupId>
-			<artifactId>org.osgi.test.assertj</artifactId>
+			<artifactId>org.osgi.test.assertj.framework</artifactId>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/cdi-itests/weld-itest.bndrun
+++ b/cdi-itests/weld-itest.bndrun
@@ -20,6 +20,7 @@
 -runblacklist: \
 	osgi.identity;filter:='(osgi.identity=*owb*)'
 -runbundles: \
+	assertj-core;version='[3.16.1,3.16.2)',\
 	biz.aQute.junit;version='[5.1.0,5.1.1)',\
 	jboss-classfilewriter;version='[1.2.4,1.2.5)',\
 	org.apache.aries.cdi.extender;version='[1.1.2,1.1.3)',\

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 		<mp.config.version>1.3</mp.config.version>
 		<mp.jwt.auth.version>1.1.1</mp.jwt.auth.version>
 		<mp.metrics.version>1.1.1</mp.metrics.version>
-		<osgi.test.version>0.9.0-SNAPSHOT</osgi.test.version>
+		<osgi.test.version>0.9.0</osgi.test.version>
 		<owb.version>2.0.13</owb.version>
 		<slf4j.version>1.7.28</slf4j.version>
 		<surefire.version>2.12</surefire.version>
@@ -289,7 +289,7 @@
 			</dependency>
 			<dependency>
 				<groupId>org.osgi</groupId>
-				<artifactId>org.osgi.test.assertj</artifactId>
+				<artifactId>org.osgi.test.assertj.framework</artifactId>
 				<version>${osgi.test.version}</version>
 				<scope>test</scope>
 			</dependency>


### PR DESCRIPTION
When I tried to do a local `mvn clean install` on this repo I got some errors due to 0.9.0-SNAPSHOT not being available.  I fixed this by switching to `0.9.0` published version.