### PR TITLE
fixed flaky tests in checkMerge_1

### DIFF
--- a/cdi-extender/src/main/java/org/apache/aries/cdi/container/internal/container/ContainerState.java
+++ b/cdi-extender/src/main/java/org/apache/aries/cdi/container/internal/container/ContainerState.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.LinkedHashSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -111,7 +112,7 @@ public class ContainerState {
 
 		_cdiAttributes = unmodifiableMap(cdiAttributes);
 
-		Set<String> extensionRequirements = new HashSet<>();
+		Set<String> extensionRequirements = new LinkedHashSet<>();
 
 		collectExtensionRequirements(bundleWiring, extensionRequirements);
 

--- a/cdi-extender/src/test/java/org/apache/aries/cdi/container/internal/model/MapsTest.java
+++ b/cdi-extender/src/test/java/org/apache/aries/cdi/container/internal/model/MapsTest.java
@@ -67,13 +67,28 @@ public class MapsTest extends AbstractTestBase {
 		Map<String, ?> merged = Maps.merge(
 			Stream.of(getClass().getField("one").getAnnotations()).collect(Collectors.toList()));
 
-		Assert.assertEquals(
-			Maps.of(
-				"a", Arrays.asList("foo", "bar", "baz"),
-				"cpt3", true,
-				"b", Arrays.asList(1,1,1,2,2),
-				"c", true),
-			merged);
+		Assert.assertTrue(
+                        Maps.of(
+                                "a", Arrays.asList("foo", "bar", "baz"),
+                                "cpt3", true,
+                                "b", Arrays.asList(1,1,1,2,2),
+                                "c", true).equals(merged) ||
+                        Maps.of(
+                                "a", Arrays.asList("foo", "bar", "baz"),
+                                "cpt3", true,
+                                "b", Arrays.asList(2,2,1,1,1),
+                                "c", true).equals(merged) ||
+                        Maps.of(
+                                "a", Arrays.asList("baz","foo", "bar"),
+                                "cpt3", true,
+                                "b", Arrays.asList(1,1,1,2,2),
+                                "c", true).equals(merged) ||
+                        Maps.of(
+                                "a", Arrays.asList("baz","foo", "bar"),
+                                "cpt3", true,
+                                "b", Arrays.asList(2,2,1,1,1),
+                                "c", true).equals(merged)
+			);
 	}
 
 	@CPT1(a = {"foo", "bar"}, b = {1, 1, 1}, c = true)


### PR DESCRIPTION
I have fixed two flaky tests: `checkMerge_1()` and `extensions_simple()`.

For `checkMerge_1()`, the `getAnnotations()` method is not guaranteed to return the annotations in the order written above the field. Thus when these lists are merged annotation1 may be added to annotation2 or vice versa. Thus to correctly test the method you should consider all possible cases: 

1) `"baz"` is appended to `{"foo", "bar"}`
2) `{"foo", "bar"}` is appended to {"baz"}
3) `{2, 2}` is appended to `{1, 1, 1}`
4) `{1, 1, 1}` is appended to `{2, 2}`


Secondly, `extensions_simple()` checks for 
`assertEquals("(&(foo=name)(service.bundleid=1))", containerDTO.template.extensions.get(0).serviceFilter);
assertEquals("(&(fum=bar)(service.bundleid=1))", containerDTO.template.extensions.get(1).serviceFilter);`

However, the `containerDTO.template.extensions` receives its elements from the HashSet object `extensionRequirements` (defined in `ContainerState.java`) when the `forEach` method is called. The issue is that the iterated order of a Hashset is not guaranteed. So for eg `(&(foo=name)(service.bundleid=1))` can be equal to `containerDTO.template.extensions.get(0).serviceFilter` or  `containerDTO.template.extensions.get(1).serviceFilter`. Since your test case assumes that the items in HashSet are returned in the order they were inserted, then a LinkedHashSet should be used. This would make your assumption true and fix the flaky test.
